### PR TITLE
Add define methods to mimic ruby accessors

### DIFF
--- a/lib/surrogate/endower.rb
+++ b/lib/surrogate/endower.rb
@@ -78,7 +78,28 @@ class Surrogate
 
     def enable_defining_methods(klass)
       def klass.define(method_name, options={}, &block)
-        @hatchery.define method_name, options, &block
+        @hatchery.define method_name.to_sym, options, &block
+      end
+
+      def klass.define_reader(*method_names, &block)
+        block ||= lambda {}
+        method_names.each { |method_name| define method_name, &block }
+        self
+      end
+
+      def klass.define_writer(*method_names)
+        method_names.each do |method_name|
+          define "#{method_name}=" do |value|
+            instance_variable_set("@#{method_name}", value)
+          end
+        end
+        self
+      end
+
+      def klass.define_accessor(*method_names, &block)
+        define_reader(*method_names, &block)
+        define_writer(*method_names)
+        self
       end
     end
 

--- a/lib/surrogate/hatchling.rb
+++ b/lib/surrogate/hatchling.rb
@@ -19,7 +19,9 @@ class Surrogate
     def invoke_method(method_name, args, &block)
       invocation = Invocation.new(args, &block)
       invoked_methods[method_name] << invocation
-      return get_default method_name, invocation, &block unless has_ivar? method_name
+      if setter?(method_name) || !has_ivar?(method_name)
+        return get_default method_name, invocation, &block
+      end
       interfaces_must_match! method_name, args
       Value.factory(get_ivar method_name).value(method_name)
     end
@@ -34,6 +36,10 @@ class Surrogate
     end
 
   private
+
+    def setter?(method_name)
+      method_name.match(/\w=$/)
+    end
 
     def invoked_methods
       @invoked_methods ||= Hash.new do |hash, method_name|

--- a/lib/surrogate/rspec/invocation_matcher.rb
+++ b/lib/surrogate/rspec/invocation_matcher.rb
@@ -9,7 +9,7 @@ class Surrogate
       attr_accessor :times_predicate, :with_filter, :surrogate, :method_name
 
       def initialize(method_name)
-        self.method_name     = method_name
+        self.method_name     = method_name.to_sym
         self.times_predicate = TimesPredicate.new
         self.with_filter     = WithFilter.new
       end

--- a/spec/rspec/verb_matcher_spec.rb
+++ b/spec/rspec/verb_matcher_spec.rb
@@ -23,12 +23,20 @@ shared_examples_for 'a verb matcher' do
   describe 'default use case' do
     before { mocked_class.define :kick, default: [] }
 
-    example 'passes if has been invoked at least once' do
+    example 'passes with a symbol if has been invoked at least once' do
       did_not :kick
       instance.kick
       did :kick
       instance.kick
       did :kick
+    end
+
+    example 'passes with a string if invoked at least once' do
+      did_not "kick"
+      instance.kick
+      did "kick"
+      instance.kick
+      did "kick"
     end
 
     example 'failure message for should' do


### PR DESCRIPTION
- Add define_reader, define_reader and define_accessor
- Can take a variable number of arguments similarly to attr_accessor
- The default reader value can be specified by passing in a block
- Allow defining of methods to take symbol or string
- Update invocation matcher to take method_name as symbol or string
