### PR TITLE
Remove order warning on substituability matcher

### DIFF
--- a/lib/surrogate/api_comparer.rb
+++ b/lib/surrogate/api_comparer.rb
@@ -10,7 +10,6 @@ class Surrogate
 
     def initialize(actual, surrogate)
       unless surrogate.instance_variable_get(:@hatchery).kind_of?(Hatchery) && surrogate.instance_variable_get(:@hatchling).kind_of?(Hatchling)
-        Kernel.warn "You said #{actual} should substitute for #{surrogate}`, but as of 0.6.2, this should be asserted in the other direction."
         surrogate, actual = actual, surrogate
       end
       self.surrogate, self.actual = surrogate, actual

--- a/lib/surrogate/rspec.rb
+++ b/lib/surrogate/rspec.rb
@@ -23,6 +23,10 @@ class Surrogate
     end
 
     module Matchers
+      def be_substitutable_for(original_class, options={})
+        SubstitutionMatcher.new original_class, options
+      end
+
       def substitute_for(original_class, options={})
         SubstitutionMatcher.new original_class, options
       end

--- a/spec/rspec/substitute_for_spec.rb
+++ b/spec/rspec/substitute_for_spec.rb
@@ -1,19 +1,22 @@
 require 'spec_helper'
 
-describe 'substitute_for' do
-  context 'understands that the non-surrogate class should substitute for the surrogate class when' do
-    specify 'the surrogate class comes first (but it does emit a warning)' do
-      Kernel.should_receive(:warn).twice.with kind_of String
+describe 'substutability matchers' do
+  context 'understand that the non-surrogate class should substitute for the surrogate class when' do
+    specify 'the surrogate class comes first' do
       surrogate = Surrogate.endow(Class.new).define(:some_meth)
       surrogate.should_not substitute_for Class.new
+      surrogate.should_not be_substitutable_for Class.new
       surrogate.should substitute_for Class.new { def some_meth() end }
+      surrogate.should be_substitutable_for Class.new { def some_meth() end }
     end
 
-    it 'the non-surrogate class comes first (and it does not emit a warning)' do
+    it 'the non-surrogate class comes first' do
       Kernel.should_not_receive :warn
       surrogate = Surrogate.endow(Class.new).define(:some_meth)
       Class.new.should_not substitute_for surrogate
+      Class.new.should_not be_substitutable_for surrogate
       Class.new { def some_meth() end }.should substitute_for surrogate
+      Class.new { def some_meth() end }.should be_substitutable_for surrogate
     end
   end
 


### PR DESCRIPTION
Add be_substitutable_for that behaves the same as substitute_for
