### PR TITLE
RSpecMatchAsserter supports rspec-3.0.0.rc

### DIFF
--- a/gemfiles/rspec_mocks_3.0.0.rc
+++ b/gemfiles/rspec_mocks_3.0.0.rc
@@ -1,0 +1,8 @@
+# set this with
+# export BUNDLE_GEMFILE=gemfiles/rspec_mocks_3.0.0.rc
+
+source "https://rubygems.org"
+
+gemspec path: File.expand_path('../..', __FILE__)
+
+gem "rspec", "~> 3.0.0.rc", group: :development # squiggly is on purpose

--- a/lib/surrogate/rspec/with_filter.rb
+++ b/lib/surrogate/rspec/with_filter.rb
@@ -17,12 +17,16 @@ class Surrogate
         end
 
         def matcher_class
-          return ::RSpec::Mocks::ArgumentListMatcher if approximate_2_11?
+          return ::RSpec::Mocks::ArgumentListMatcher if approximate_2_11? || approximate_3_0_0_rc?
           ::RSpec::Mocks::ArgumentExpectation
         end
 
         def approximate_2_11?
           Gem::Requirement.create('~> 2.11').satisfied_by? Gem::Version.new(::RSpec::Mocks::Version::STRING)
+        end
+
+        def approximate_3_0_0_rc?
+          Gem::Requirement.create('~> 3.0.0.rc').satisfied_by? Gem::Version.new(::RSpec::Mocks::Version::STRING)
         end
       end
 

--- a/lib/surrogate/version.rb
+++ b/lib/surrogate/version.rb
@@ -1,3 +1,3 @@
 class Surrogate
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/spec/unit/argument_errorizer_spec.rb
+++ b/spec/unit/argument_errorizer_spec.rb
@@ -43,10 +43,10 @@ describe Surrogate::ArgumentErrorizer do
     assert_message ->(){},                           [1],   "wrong number of arguments (1 for 0) in #{meth_name}()"
     assert_message ->(a){},                          [],    "wrong number of arguments (0 for 1) in #{meth_name}(a)"
     assert_message ->(a){},                          [],    "wrong number of arguments (0 for 1) in #{meth_name}(a)"
-    assert_message ->(a=1){},                        [1,2], "wrong number of arguments (2 for 1) in #{meth_name}(a='?')"
-    assert_message ->(a, *b){},                      [],    "wrong number of arguments (0 for 1) in #{meth_name}(a, *b)"
-    assert_message ->(a, *b, &c){},                  [],    "wrong number of arguments (0 for 1) in #{meth_name}(a, *b, &c)"
-    assert_message ->(a, b, c=1, d=1, *e, f, &g){},  [],    "wrong number of arguments (0 for 3) in #{meth_name}(a, b, c='?', d='?', *e, f, &g)"
+    assert_message ->(a=1){},                        [1,2], "wrong number of arguments (2 for 0..1) in #{meth_name}(a='?')"
+    assert_message ->(a, *b){},                      [],    "wrong number of arguments (0 for 1+) in #{meth_name}(a, *b)"
+    assert_message ->(a, *b, &c){},                  [],    "wrong number of arguments (0 for 1+) in #{meth_name}(a, *b, &c)"
+    assert_message ->(a, b, c=1, d=1, *e, f, &g){},  [],    "wrong number of arguments (0 for 3+) in #{meth_name}(a, b, c='?', d='?', *e, f, &g)"
   end
 
   it 'raises an ArgumentError if initialized with a non lambda/method' do


### PR DESCRIPTION
Some notes:
1. This supports all `rspec-3.0.0.rc` versions. The conditional in `lib/surrogate/rspec/with_filter.rb` will need to be updated when `rspec-3.0.0` officially comes out.
2. I've included a `Gemfile` specifically for `rspec-3.0.0.rc` versions.
3. I probably messed up, but I gave it up a minor bump. It should not affect existing users.
4. The updates to `spec/unit/argument_errorizer_spec.rb` will only work for `rspec-3.0.0.rc` or newer.
