### PR TITLE
RSpec patch

### DIFF
--- a/lib/surrogate/rspec.rb
+++ b/lib/surrogate/rspec.rb
@@ -67,8 +67,10 @@ class Surrogate
 
   Endower.add_hook do |klass|
     klass.class_eval do
-      alias was should
-      alias was_not should_not
+      if respond_to?(:should)
+        alias was should
+        alias was_not should_not
+      end
     end
   end
 end

--- a/lib/surrogate/rspec/substitution_matcher.rb
+++ b/lib/surrogate/rspec/substitution_matcher.rb
@@ -49,7 +49,7 @@ class Surrogate
       end
 
       alias failure_message               failure_message_for_should
-      alias failure_message_when_negated  failure_message_for_should
+      alias failure_message_when_negated  failure_message_for_should_not
 
     private
 

--- a/lib/surrogate/rspec/substitution_matcher.rb
+++ b/lib/surrogate/rspec/substitution_matcher.rb
@@ -48,6 +48,9 @@ class Surrogate
         "Should not have been substitute, but was"
       end
 
+      alias failure_message               failure_message_for_should
+      alias failure_message_when_negated  failure_message_for_should
+
     private
 
       def comparing_fields(comparison, subset_only, types, names)


### PR DESCRIPTION
- Aliases '#should' to '#was' only when '#should' is defined on the object i.e. monkey-patching is enabled in rspec. Endower hook will currently fail when using rspec 3 in zero monkey-patching mode. 
- Adds aliased failure message methods to substitution matcher in order to make RSpec 3 happy. Currently it runs fine, but raises deprecation warnings.
