### PR TITLE
Allow will_<api_method> to accept a block

### DIFF
--- a/lib/surrogate/values.rb
+++ b/lib/surrogate/values.rb
@@ -6,7 +6,9 @@ class Surrogate
     # convert raw arguments into a value
     def self.factory(*args, &block)
       arg = args.first
-      if args.size > 1
+      if block
+        BlockValue.new &block
+      elsif args.size > 1
         ValueQueue.new args
       elsif arg.kind_of? Exception
         Raisable.new arg
@@ -33,6 +35,16 @@ class Surrogate
       end
     end
 
+
+    class BlockValue < BaseValue
+      def initialize(&block)
+        @block = block
+      end
+
+      def value(method_name)
+        @block.call
+      end
+    end
 
     class Raisable < BaseValue
       def value(*)

--- a/spec/defining_api_methods_spec.rb
+++ b/spec/defining_api_methods_spec.rb
@@ -73,6 +73,21 @@ describe 'define' do
         it 'returns the object' do
           instance.will_wink(:quickly).should equal instance
         end
+
+        it 'overrides the default behaviour for the api method' do
+          mock1 = mocked_class.new
+          mock2 = mocked_class.new
+          winked = false
+          mock1.will_wink do
+            winked = true
+          end
+          mock2.will_wink :quickly
+
+          winked.should == false
+          mock1.wink
+          winked.should == true
+          mock2.wink.should == :quickly
+        end
       end
 
       describe 'will_<api_method> with multiple arguments' do


### PR DESCRIPTION
This overrides the default behavior instead of just the default return value.

I was finding this behavior to be useful to create a mock that triggers callbacks.
